### PR TITLE
Remove improper use of rejections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+
+[[package]]
 name = "argh"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2485,6 +2491,7 @@ name = "tranquility"
 version = "0.1.0"
 dependencies = [
  "ammonia",
+ "anyhow",
  "argh",
  "askama",
  "async-trait",

--- a/tranquility/Cargo.toml
+++ b/tranquility/Cargo.toml
@@ -8,6 +8,7 @@ build = "build.rs"
 
 [dependencies]
 ammonia = "3"
+anyhow = "1"
 argh = "0.1"
 askama = "0.10"
 async-trait = "0.1"

--- a/tranquility/src/activitypub/handler/accept.rs
+++ b/tranquility/src/activitypub/handler/accept.rs
@@ -1,15 +1,21 @@
 use {
-    crate::{activitypub::FollowActivity, database::Object, error::Error, state::ArcState},
+    crate::{
+        activitypub::FollowActivity, database::Object, error::Error, state::ArcState,
+        unrejectable_err,
+    },
     ormx::Table,
     tranquility_types::activitypub::Activity,
-    warp::http::StatusCode,
+    warp::{http::StatusCode, reply::Response, Reply},
 };
 
-pub async fn handle(state: &ArcState, activity: Activity) -> Result<StatusCode, Error> {
-    let follow_activity_url = activity.object.as_url().ok_or(Error::UnknownActivity)?;
-    let mut follow_activity_db = Object::by_url(&state.db_pool, follow_activity_url).await?;
+pub async fn handle(state: &ArcState, activity: Activity) -> Result<Response, Error> {
+    let follow_activity_url =
+        unrejectable_err!(activity.object.as_url().ok_or(Error::UnknownActivity));
+    let mut follow_activity_db =
+        unrejectable_err!(Object::by_url(&state.db_pool, follow_activity_url).await);
 
-    let mut follow_activity: FollowActivity = serde_json::from_value(follow_activity_db.data)?;
+    let mut follow_activity: FollowActivity =
+        unrejectable_err!(serde_json::from_value(follow_activity_db.data));
     // Check if the person rejecting the follow is actually the followed person
     if &activity.actor != follow_activity.activity.object.as_url().unwrap() {
         return Err(Error::Unauthorized);
@@ -24,7 +30,7 @@ pub async fn handle(state: &ArcState, activity: Activity) -> Result<StatusCode, 
     // Update the activity
     let follow_activity_value = serde_json::to_value(&follow_activity)?;
     follow_activity_db.data = follow_activity_value;
-    follow_activity_db.update(&state.db_pool).await?;
+    unrejectable_err!(follow_activity_db.update(&state.db_pool).await);
 
-    Ok(StatusCode::OK)
+    Ok(StatusCode::OK.into_response())
 }

--- a/tranquility/src/activitypub/handler/like.rs
+++ b/tranquility/src/activitypub/handler/like.rs
@@ -4,30 +4,33 @@ use {
         database::{Actor, InsertExt, InsertObject},
         error::Error,
         state::ArcState,
+        unrejectable_err,
     },
     tranquility_types::activitypub::Activity,
     uuid::Uuid,
-    warp::http::StatusCode,
+    warp::{http::StatusCode, reply::Response, Reply},
 };
 
-pub async fn handle(state: &ArcState, activity: Activity) -> Result<StatusCode, Error> {
+pub async fn handle(state: &ArcState, activity: Activity) -> Result<Response, Error> {
     let object_url = activity.object.as_url().ok_or(Error::UnknownActivity)?;
 
     // Fetch the object (just in case)
-    fetcher::fetch_object(&state, &object_url).await?;
+    unrejectable_err!(fetcher::fetch_object(&state, &object_url).await);
     // Fetch the actor (just in case)
-    fetcher::fetch_actor(&state, &activity.actor).await?;
-    let actor = Actor::by_url(&state.db_pool, &activity.actor).await?;
+    unrejectable_err!(fetcher::fetch_actor(&state, &activity.actor).await);
+    let actor = unrejectable_err!(Actor::by_url(&state.db_pool, &activity.actor).await);
 
     let activity_value = serde_json::to_value(&activity)?;
 
-    InsertObject {
-        id: Uuid::new_v4(),
-        owner_id: actor.id,
-        data: activity_value,
-    }
-    .insert(&state.db_pool)
-    .await?;
+    unrejectable_err!(
+        InsertObject {
+            id: Uuid::new_v4(),
+            owner_id: actor.id,
+            data: activity_value,
+        }
+        .insert(&state.db_pool)
+        .await
+    );
 
-    Ok(StatusCode::CREATED)
+    Ok(StatusCode::CREATED.into_response())
 }

--- a/tranquility/src/activitypub/handler/undo.rs
+++ b/tranquility/src/activitypub/handler/undo.rs
@@ -1,16 +1,16 @@
 use {
-    crate::{database::Object, error::Error, state::ArcState},
+    crate::{database::Object, error::Error, state::ArcState, unrejectable_err},
     tranquility_types::activitypub::Activity,
-    warp::http::StatusCode,
+    warp::{http::StatusCode, reply::Response, Reply},
 };
 
-pub async fn handle(state: &ArcState, delete_activity: Activity) -> Result<StatusCode, Error> {
+pub async fn handle(state: &ArcState, delete_activity: Activity) -> Result<Response, Error> {
     let activity_url = delete_activity
         .object
         .as_url()
         .ok_or(Error::UnknownActivity)?;
 
-    Object::delete_by_url(&state.db_pool, activity_url).await?;
+    unrejectable_err!(Object::delete_by_url(&state.db_pool, activity_url).await);
 
-    Ok(StatusCode::CREATED)
+    Ok(StatusCode::CREATED.into_response())
 }

--- a/tranquility/src/activitypub/interactions.rs
+++ b/tranquility/src/activitypub/interactions.rs
@@ -1,14 +1,13 @@
 use {
     crate::{
         database::{Actor as DbActor, InsertExt, InsertObject, Object as DbObject},
-        error::Error,
         state::ArcState,
     },
     std::sync::Arc,
     tranquility_types::activitypub::{Activity, Actor},
 };
 
-pub async fn follow(state: &ArcState, db_actor: DbActor, followed: &Actor) -> Result<(), Error> {
+pub async fn follow(state: &ArcState, db_actor: DbActor, followed: &Actor) -> anyhow::Result<()> {
     let actor: Actor = serde_json::from_value(db_actor.actor)?;
 
     // Check if there's already a follow activity
@@ -47,12 +46,11 @@ pub async fn follow(state: &ArcState, db_actor: DbActor, followed: &Actor) -> Re
     Ok(())
 }
 
-pub async fn undo(state: &ArcState, db_actor: DbActor, db_activity: DbObject) -> Result<(), Error> {
-    // Tried to delete someone else's activity
-    if db_activity.owner_id != db_actor.id {
-        return Err(Error::Unauthorized);
-    }
-
+pub async fn undo(
+    state: &ArcState,
+    db_actor: DbActor,
+    db_activity: DbObject,
+) -> anyhow::Result<()> {
     let activity: Activity = serde_json::from_value(db_activity.data)?;
     let actor: Actor = serde_json::from_value(db_actor.actor)?;
 
@@ -84,7 +82,7 @@ pub async fn unfollow(
     state: &ArcState,
     db_actor: DbActor,
     followed_db_actor: DbActor,
-) -> Result<(), Error> {
+) -> anyhow::Result<()> {
     let followed_actor: Actor = serde_json::from_value(followed_db_actor.actor)?;
 
     let follow_activity = DbObject::by_type_owner_and_object_url(

--- a/tranquility/src/activitypub/routes/following.rs
+++ b/tranquility/src/activitypub/routes/following.rs
@@ -2,7 +2,7 @@ use {
     super::CollectionQuery,
     crate::{
         activitypub::FollowActivity, consts::activitypub::ACTIVITIES_PER_PAGE,
-        database::Actor as DbActor, format_uuid, map_err, state::ArcState,
+        database::Actor as DbActor, format_uuid, state::ArcState, unrejectable_err,
     },
     itertools::Itertools,
     ormx::Table,
@@ -10,21 +10,23 @@ use {
         collection::Item, Actor, Collection, OUTBOX_FOLLOW_COLLECTIONS_PAGE_TYPE,
     },
     uuid::Uuid,
-    warp::{Rejection, Reply},
+    warp::{reply::Response, Rejection, Reply},
 };
 
 pub async fn following(
     user_id: Uuid,
     state: ArcState,
     query: CollectionQuery,
-) -> Result<impl Reply, Rejection> {
-    let latest_follow_activities = crate::database::follow::following(
-        &state.db_pool,
-        user_id,
-        query.last_id,
-        ACTIVITIES_PER_PAGE,
-    )
-    .await?;
+) -> Result<Response, Rejection> {
+    let latest_follow_activities = unrejectable_err!(
+        crate::database::follow::following(
+            &state.db_pool,
+            user_id,
+            query.last_id,
+            ACTIVITIES_PER_PAGE,
+        )
+        .await
+    );
     let last_id = latest_follow_activities
         .last()
         .map(|activity| format_uuid!(activity.id))
@@ -40,8 +42,8 @@ pub async fn following(
         })
         .collect_vec();
 
-    let user_db = map_err!(DbActor::get(&state.db_pool, user_id).await)?;
-    let user: Actor = map_err!(serde_json::from_value(user_db.actor))?;
+    let user_db = unrejectable_err!(DbActor::get(&state.db_pool, user_id).await);
+    let user: Actor = unrejectable_err!(serde_json::from_value(user_db.actor));
 
     let next = format!("{}?last_id={}", user.following, last_id);
 
@@ -57,5 +59,5 @@ pub async fn following(
         ..Collection::default()
     };
 
-    Ok(warp::reply::json(&following_collection))
+    Ok(warp::reply::json(&following_collection).into_response())
 }

--- a/tranquility/src/activitypub/routes/mod.rs
+++ b/tranquility/src/activitypub/routes/mod.rs
@@ -1,5 +1,9 @@
 use {
-    crate::{consts::MAX_BODY_SIZE, error::Error, map_err, state::ArcState},
+    crate::{
+        consts::MAX_BODY_SIZE,
+        error::{Error, IntoRejection},
+        state::ArcState,
+    },
     serde::{de::DeserializeOwned, Deserialize},
     uuid::Uuid,
     warp::{hyper::body::Bytes, Filter, Rejection, Reply},
@@ -29,7 +33,7 @@ fn header_requirements() -> impl Filter<Extract = (), Error = Rejection> + Copy 
 // requests have the types of either "application/ld+json" or "application/activity+json"
 fn ap_json<T: DeserializeOwned>() -> impl Filter<Extract = (T,), Error = Rejection> + Copy {
     let custom_json_parser_fn = |body: Bytes| async move {
-        let value = map_err!(serde_json::from_slice(&body))?;
+        let value = serde_json::from_slice(&body).into_rejection()?;
 
         Ok::<T, Rejection>(value)
     };

--- a/tranquility/src/activitypub/routes/objects.rs
+++ b/tranquility/src/activitypub/routes/objects.rs
@@ -1,13 +1,14 @@
 use {
-    crate::{activitypub::ActivityObject, database::Object, map_err, state::ArcState},
+    crate::{activitypub::ActivityObject, database::Object, state::ArcState, unrejectable_err},
     tranquility_types::activitypub::IsPrivate,
     uuid::Uuid,
     warp::{http::StatusCode, reply::Response, Rejection, Reply},
 };
 
 pub async fn objects(id: Uuid, state: ArcState) -> Result<Response, Rejection> {
-    let object = Object::by_id(&state.db_pool, id).await?;
-    let activity_or_object: ActivityObject = map_err!(serde_json::from_value(object.data.clone()))?;
+    let object = unrejectable_err!(Object::by_id(&state.db_pool, id).await);
+    let activity_or_object: ActivityObject =
+        unrejectable_err!(serde_json::from_value(object.data.clone()));
 
     // Do not expose private activities/object publicly
     if activity_or_object.is_private() {

--- a/tranquility/src/activitypub/routes/users.rs
+++ b/tranquility/src/activitypub/routes/users.rs
@@ -1,12 +1,12 @@
 use {
-    crate::{database::Actor, map_err, state::ArcState},
+    crate::{database::Actor, state::ArcState, unrejectable_err},
     ormx::Table,
     uuid::Uuid,
-    warp::{Rejection, Reply},
+    warp::{reply::Response, Rejection, Reply},
 };
 
-pub async fn users(uuid: Uuid, state: ArcState) -> Result<impl Reply, Rejection> {
-    let actor = map_err!(Actor::get(&state.db_pool, uuid).await)?;
+pub async fn users(uuid: Uuid, state: ArcState) -> Result<Response, Rejection> {
+    let actor = unrejectable_err!(Actor::get(&state.db_pool, uuid).await);
 
-    Ok(warp::reply::json(&actor.actor))
+    Ok(warp::reply::json(&actor.actor).into_response())
 }

--- a/tranquility/src/api/mastodon/apps.rs
+++ b/tranquility/src/api/mastodon/apps.rs
@@ -3,10 +3,11 @@ use {
     crate::{
         database::{InsertExt, InsertOAuthApplication},
         state::ArcState,
+        unrejectable_err,
     },
     serde::Deserialize,
     uuid::Uuid,
-    warp::{Filter, Rejection, Reply},
+    warp::{reply::Response, Filter, Rejection, Reply},
 };
 
 fn default_scopes() -> String {
@@ -23,23 +24,25 @@ pub struct RegisterForm {
     website: String,
 }
 
-async fn create(state: ArcState, form: RegisterForm) -> Result<impl Reply, Rejection> {
+async fn create(state: ArcState, form: RegisterForm) -> Result<Response, Rejection> {
     let client_id = Uuid::new_v4();
-    let client_secret = crate::crypto::token::generate()?;
+    let client_secret = unrejectable_err!(crate::crypto::token::generate());
 
-    let application = InsertOAuthApplication {
-        client_name: form.client_name,
-        client_id,
-        client_secret,
-        redirect_uris: form.redirect_uris,
-        scopes: form.scopes,
-        website: form.website,
-    }
-    .insert(&state.db_pool)
-    .await?;
-    let mastodon_application = application.into_mastodon(&state).await?;
+    let application = unrejectable_err!(
+        InsertOAuthApplication {
+            client_name: form.client_name,
+            client_id,
+            client_secret,
+            redirect_uris: form.redirect_uris,
+            scopes: form.scopes,
+            website: form.website,
+        }
+        .insert(&state.db_pool)
+        .await
+    );
+    let mastodon_application = unrejectable_err!(application.into_mastodon(&state).await);
 
-    Ok(warp::reply::json(&mastodon_application))
+    Ok(warp::reply::json(&mastodon_application).into_response())
 }
 
 pub fn routes(state: &ArcState) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {

--- a/tranquility/src/database/actor.rs
+++ b/tranquility/src/database/actor.rs
@@ -1,7 +1,4 @@
-use {
-    crate::error::Error, chrono::NaiveDateTime, ormx::Table, serde_json::Value, sqlx::PgPool,
-    uuid::Uuid,
-};
+use {chrono::NaiveDateTime, ormx::Table, serde_json::Value, sqlx::PgPool, uuid::Uuid};
 
 #[derive(Clone, Table)]
 #[ormx(id = id, table = "actors", insertable)]
@@ -24,7 +21,7 @@ pub struct Actor {
 }
 
 impl Actor {
-    pub async fn by_url(conn_pool: &PgPool, url: &str) -> Result<Self, Error> {
+    pub async fn by_url(conn_pool: &PgPool, url: &str) -> anyhow::Result<Self> {
         let actor = sqlx::query_as!(
             Actor,
             r#"
@@ -39,7 +36,7 @@ impl Actor {
         Ok(actor)
     }
 
-    pub async fn by_username_local(conn_pool: &PgPool, username: &str) -> Result<Self, Error> {
+    pub async fn by_username_local(conn_pool: &PgPool, username: &str) -> anyhow::Result<Self> {
         let actor = sqlx::query_as!(
             Actor,
             r#"

--- a/tranquility/src/database/follow.rs
+++ b/tranquility/src/database/follow.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        database::{last_activity_timestamp, Object},
-        error::Error,
-    },
+    crate::database::{last_activity_timestamp, Object},
     sqlx::PgPool,
     uuid::Uuid,
 };
@@ -12,7 +9,7 @@ pub async fn followers(
     user_id: Uuid,
     last_activity_id: Option<Uuid>,
     limit: i64,
-) -> Result<Vec<Object>, Error> {
+) -> anyhow::Result<Vec<Object>> {
     let last_activity_timestamp = last_activity_timestamp(conn_pool, last_activity_id).await?;
     let follow_activities = sqlx::query_as!(
         Object,
@@ -41,7 +38,7 @@ pub async fn following(
     user_id: Uuid,
     last_activity_id: Option<Uuid>,
     limit: i64,
-) -> Result<Vec<Object>, Error> {
+) -> anyhow::Result<Vec<Object>> {
     let last_activity_timestamp = last_activity_timestamp(conn_pool, last_activity_id).await?;
     let follow_activities = sqlx::query_as!(
         Object,

--- a/tranquility/src/database/inbox_urls.rs
+++ b/tranquility/src/database/inbox_urls.rs
@@ -1,5 +1,4 @@
 use {
-    crate::error::Error,
     futures_util::stream::{StreamExt, TryStreamExt},
     sqlx::PgPool,
 };
@@ -19,7 +18,7 @@ impl From<InboxUrl> for String {
 pub async fn resolve_followers(
     conn_pool: &PgPool,
     followed_url: &str,
-) -> Result<Vec<String>, Error> {
+) -> anyhow::Result<Vec<String>> {
     let inbox_urls = sqlx::query_as!(
         InboxUrl,
         r#"
@@ -39,7 +38,7 @@ pub async fn resolve_followers(
     Ok(inbox_urls)
 }
 
-pub async fn resolve_one(conn_pool: &PgPool, url: &str) -> Result<String, Error> {
+pub async fn resolve_one(conn_pool: &PgPool, url: &str) -> anyhow::Result<String> {
     let inbox_url = sqlx::query_as!(
         InboxUrl,
         // The `as "inbox_url!"` is needed here for the `query_as` macro to be

--- a/tranquility/src/database/oauth/authorization.rs
+++ b/tranquility/src/database/oauth/authorization.rs
@@ -1,4 +1,4 @@
-use {crate::error::Error, chrono::NaiveDateTime, ormx::Table, sqlx::PgPool, uuid::Uuid};
+use {chrono::NaiveDateTime, ormx::Table, sqlx::PgPool, uuid::Uuid};
 
 #[derive(Clone, Table)]
 #[ormx(id = id, table = "oauth_authorizations", insertable)]
@@ -20,7 +20,7 @@ pub struct OAuthAuthorization {
 }
 
 impl OAuthAuthorization {
-    pub async fn delete_expired(conn_pool: &PgPool) -> Result<(), Error> {
+    pub async fn delete_expired(conn_pool: &PgPool) -> anyhow::Result<()> {
         sqlx::query!("DELETE FROM oauth_authorizations WHERE valid_until < NOW()")
             .execute(conn_pool)
             .await?;

--- a/tranquility/src/database/outbox.rs
+++ b/tranquility/src/database/outbox.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        database::{last_activity_timestamp, Object},
-        error::Error,
-    },
+    crate::database::{last_activity_timestamp, Object},
     sqlx::PgPool,
     uuid::Uuid,
 };
@@ -12,7 +9,7 @@ pub async fn activities(
     user_id: Uuid,
     last_activity_id: Option<Uuid>,
     limit: i64,
-) -> Result<Vec<Object>, Error> {
+) -> anyhow::Result<Vec<Object>> {
     let last_activity_timestamp = last_activity_timestamp(conn_pool, last_activity_id).await?;
     let create_activities = sqlx::query_as!(
         Object,


### PR DESCRIPTION
Currently we have one giant `Error` enum for every possible error that could happen inside Tranquility so we can convert those errors to the enum and the enum into an `Rejection`

However, this isn't how rejections are supposed to be used. See [this comment](https://github.com/seanmonstar/warp/issues/712#issuecomment-697031645)
