### PR TITLE
feat: Configuration reload

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+SQLX_OFFLINE=true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -116,12 +116,9 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions-rs/cargo@v1
+      - run: ./run_tests.sh
         env:
           TEST_DB_URL: postgres://tranquility:tranquility@localhost:5432/tests
-        with:
-          command: test
-          args: -- --show-output
 
   fmt:
     name: Rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e906254e445520903e7fc9da4f709886c84ae4bc4ddaf0e093188d66df4dc820"
+
+[[package]]
 name = "argh"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +481,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +523,15 @@ name = "fs_extra"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e564d24da983c053beff1bb7178e237501206840a3e6bf4e267b9e8ae734a"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "funty"
@@ -909,6 +936,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b031475cb1b103ee221afb806a23d35e0570bf7271d7588762ceba8127ed43b3"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "input_buffer"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,6 +1049,26 @@ dependencies = [
  "regex",
  "serde_json",
  "url",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512705bfcaeb3d46379771adc69deab978355fc68fdf960f9fb11abc8d678a96"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9803ae382091c10a5c7297ffb9fde284dbc9662b249f86eacef605d97ae92d99"
+dependencies = [
+ "bitflags",
+ "libc",
 ]
 
 [[package]]
@@ -1275,6 +1342,24 @@ name = "nonzero_ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44a1290799eababa63ea60af0cbc3f03363e328e58f32fb0294798ed3e85f444"
+
+[[package]]
+name = "notify"
+version = "5.0.0-pre.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c614e7ed2b1cf82ec99aeffd8cf6225ef5021b9951148eb161393c394855032c"
+dependencies = [
+ "bitflags",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "mio",
+ "walkdir",
+ "winapi",
+]
 
 [[package]]
 name = "ntapi"
@@ -2000,6 +2085,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2656,6 +2750,7 @@ name = "tranquility"
 version = "0.1.0"
 dependencies = [
  "ammonia",
+ "arc-swap",
  "argh",
  "askama",
  "async-trait",
@@ -2670,6 +2765,7 @@ dependencies = [
  "jsonschema",
  "lettre",
  "mimalloc",
+ "notify",
  "once_cell",
  "opentelemetry",
  "opentelemetry-jaeger",
@@ -2903,6 +2999,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3076,6 +3183,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cargo test -- --test-threads=1 --show-output

--- a/tranquility/Cargo.toml
+++ b/tranquility/Cargo.toml
@@ -8,6 +8,7 @@ build = "build.rs"
 
 [dependencies]
 ammonia = "3.1.2"
+arc-swap = "1.3.0"
 argh = "0.1.5"
 askama = "0.10.5"
 async-trait = "0.1.50"
@@ -56,6 +57,7 @@ pulldown-cmark = { version = "0.8.0", default-features = false, optional = true 
 # Memory allocators (optional)
 jemalloc = { package = "jemallocator", version = "0.3.2", optional = true }
 mimalloc = { version = "0.1.26", optional = true }
+notify = "5.0.0-pre.11"
 
 [dependencies.tranquility-http-signatures]
 path = "../tranquility-http-signatures"

--- a/tranquility/src/activitypub/handler/accept.rs
+++ b/tranquility/src/activitypub/handler/accept.rs
@@ -1,12 +1,14 @@
 use {
-    crate::{activitypub::FollowActivity, database::Object, error::Error, state::ArcState},
+    crate::{activitypub::FollowActivity, database::Object, error::Error},
     ormx::Table,
     tranquility_types::activitypub::Activity,
     warp::http::StatusCode,
 };
 
-pub async fn handle(state: &ArcState, activity: Activity) -> Result<StatusCode, Error> {
+pub async fn handle(activity: Activity) -> Result<StatusCode, Error> {
     let follow_activity_url = activity.object.as_url().ok_or(Error::UnknownActivity)?;
+
+    let state = crate::state::get();
     let mut follow_activity_db = Object::by_url(&state.db_pool, follow_activity_url).await?;
 
     let mut follow_activity: FollowActivity = serde_json::from_value(follow_activity_db.data)?;

--- a/tranquility/src/activitypub/handler/announce.rs
+++ b/tranquility/src/activitypub/handler/announce.rs
@@ -3,21 +3,21 @@ use {
         activitypub::fetcher,
         database::{Actor, InsertExt, InsertObject},
         error::Error,
-        state::ArcState,
     },
     tranquility_types::activitypub::Activity,
     uuid::Uuid,
     warp::http::StatusCode,
 };
 
-pub async fn handle(state: &ArcState, activity: Activity) -> Result<StatusCode, Error> {
+pub async fn handle(activity: Activity) -> Result<StatusCode, Error> {
     let object_url = activity.object.as_url().ok_or(Error::UnknownActivity)?;
 
     // Fetch the object (just in case)
-    fetcher::fetch_object(&state, &object_url).await?;
+    fetcher::fetch_object(&object_url).await?;
     // Fetch the actor (just in case)
-    fetcher::fetch_actor(&state, &activity.actor).await?;
+    fetcher::fetch_actor(&activity.actor).await?;
 
+    let state = crate::state::get();
     let actor = Actor::by_url(&state.db_pool, &activity.actor).await?;
     let activity_value = serde_json::to_value(&activity)?;
 

--- a/tranquility/src/activitypub/handler/delete.rs
+++ b/tranquility/src/activitypub/handler/delete.rs
@@ -1,16 +1,16 @@
 use {
-    crate::{activitypub::fetcher, database::Object, error::Error, state::ArcState},
+    crate::{activitypub::fetcher, database::Object, error::Error},
     tranquility_types::activitypub::{activity::ObjectField, Activity},
     warp::http::StatusCode,
 };
 
-pub async fn handle(state: &ArcState, mut activity: Activity) -> Result<StatusCode, Error> {
+pub async fn handle(mut activity: Activity) -> Result<StatusCode, Error> {
     // Normalize activity
     match activity.object {
         ObjectField::Actor(..) => return Err(Error::UnknownActivity),
         ObjectField::Object(..) => (),
         ObjectField::Url(ref url) => {
-            let object = fetcher::fetch_object(state, url).await?;
+            let object = fetcher::fetch_object(url).await?;
 
             activity.object = ObjectField::Object(object);
         }
@@ -18,6 +18,7 @@ pub async fn handle(state: &ArcState, mut activity: Activity) -> Result<StatusCo
 
     let object = activity.object.as_object().unwrap();
 
+    let state = crate::state::get();
     Object::delete_by_url(&state.db_pool, &object.id).await?;
 
     Ok(StatusCode::CREATED)

--- a/tranquility/src/activitypub/handler/like.rs
+++ b/tranquility/src/activitypub/handler/like.rs
@@ -3,22 +3,22 @@ use {
         activitypub::fetcher,
         database::{Actor, InsertExt, InsertObject},
         error::Error,
-        state::ArcState,
     },
     tranquility_types::activitypub::Activity,
     uuid::Uuid,
     warp::http::StatusCode,
 };
 
-pub async fn handle(state: &ArcState, activity: Activity) -> Result<StatusCode, Error> {
+pub async fn handle(activity: Activity) -> Result<StatusCode, Error> {
     let object_url = activity.object.as_url().ok_or(Error::UnknownActivity)?;
 
     // Fetch the object (just in case)
-    fetcher::fetch_object(&state, &object_url).await?;
+    fetcher::fetch_object(&object_url).await?;
     // Fetch the actor (just in case)
-    fetcher::fetch_actor(&state, &activity.actor).await?;
-    let actor = Actor::by_url(&state.db_pool, &activity.actor).await?;
+    fetcher::fetch_actor(&activity.actor).await?;
 
+    let state = crate::state::get();
+    let actor = Actor::by_url(&state.db_pool, &activity.actor).await?;
     let activity_value = serde_json::to_value(&activity)?;
 
     InsertObject {

--- a/tranquility/src/activitypub/handler/reject.rs
+++ b/tranquility/src/activitypub/handler/reject.rs
@@ -1,12 +1,14 @@
 use {
-    crate::{database::Object, error::Error, state::ArcState},
+    crate::{database::Object, error::Error},
     ormx::Table,
     tranquility_types::activitypub::Activity,
     warp::http::StatusCode,
 };
 
-pub async fn handle(state: &ArcState, activity: Activity) -> Result<StatusCode, Error> {
+pub async fn handle(activity: Activity) -> Result<StatusCode, Error> {
     let follow_activity_url = activity.object.as_url().ok_or(Error::UnknownActivity)?;
+
+    let state = crate::state::get();
     let follow_activity_db = Object::by_url(&state.db_pool, follow_activity_url).await?;
     let follow_activity: Activity = serde_json::from_value(follow_activity_db.data.clone())?;
     // Check if the person rejecting the follow is actually the followed person

--- a/tranquility/src/activitypub/handler/undo.rs
+++ b/tranquility/src/activitypub/handler/undo.rs
@@ -1,15 +1,16 @@
 use {
-    crate::{database::Object, error::Error, state::ArcState},
+    crate::{database::Object, error::Error},
     tranquility_types::activitypub::Activity,
     warp::http::StatusCode,
 };
 
-pub async fn handle(state: &ArcState, delete_activity: Activity) -> Result<StatusCode, Error> {
+pub async fn handle(delete_activity: Activity) -> Result<StatusCode, Error> {
     let activity_url = delete_activity
         .object
         .as_url()
         .ok_or(Error::UnknownActivity)?;
 
+    let state = crate::state::get();
     Object::delete_by_url(&state.db_pool, activity_url).await?;
 
     Ok(StatusCode::CREATED)

--- a/tranquility/src/activitypub/handler/update.rs
+++ b/tranquility/src/activitypub/handler/update.rs
@@ -3,14 +3,13 @@ use {
         activitypub::{fetcher, Clean},
         database::Actor,
         error::Error,
-        state::ArcState,
     },
     ormx::Table,
     tranquility_types::activitypub::Activity,
     warp::http::StatusCode,
 };
 
-pub async fn handle(state: &ArcState, mut activity: Activity) -> Result<StatusCode, Error> {
+pub async fn handle(mut activity: Activity) -> Result<StatusCode, Error> {
     // Update activities are usually only used to update the actor
     // (For example, when the user changes their bio or display name)
     let ap_actor = activity
@@ -20,8 +19,9 @@ pub async fn handle(state: &ArcState, mut activity: Activity) -> Result<StatusCo
     ap_actor.clean();
 
     // Fetch the actor (just in case)
-    fetcher::fetch_actor(state, ap_actor.id.as_str()).await?;
+    fetcher::fetch_actor(ap_actor.id.as_str()).await?;
 
+    let state = crate::state::get();
     let mut actor = Actor::by_url(&state.db_pool, ap_actor.id.as_str()).await?;
 
     // Update the actor value

--- a/tranquility/src/activitypub/routes/followers.rs
+++ b/tranquility/src/activitypub/routes/followers.rs
@@ -2,7 +2,7 @@ use {
     super::CollectionQuery,
     crate::{
         activitypub::FollowActivity, consts::activitypub::ACTIVITIES_PER_PAGE,
-        database::Actor as DbActor, format_uuid, map_err, state::ArcState,
+        database::Actor as DbActor, format_uuid, map_err,
     },
     itertools::Itertools,
     tranquility_types::activitypub::{
@@ -12,11 +12,9 @@ use {
     warp::{Rejection, Reply},
 };
 
-pub async fn followers(
-    user_id: Uuid,
-    state: ArcState,
-    query: CollectionQuery,
-) -> Result<impl Reply, Rejection> {
+pub async fn followers(user_id: Uuid, query: CollectionQuery) -> Result<impl Reply, Rejection> {
+    let state = crate::state::get();
+
     let latest_follow_activities = crate::database::follow::followers(
         &state.db_pool,
         user_id,

--- a/tranquility/src/activitypub/routes/following.rs
+++ b/tranquility/src/activitypub/routes/following.rs
@@ -2,7 +2,7 @@ use {
     super::CollectionQuery,
     crate::{
         activitypub::FollowActivity, consts::activitypub::ACTIVITIES_PER_PAGE,
-        database::Actor as DbActor, format_uuid, map_err, state::ArcState,
+        database::Actor as DbActor, format_uuid, map_err,
     },
     itertools::Itertools,
     tranquility_types::activitypub::{
@@ -12,11 +12,9 @@ use {
     warp::{Rejection, Reply},
 };
 
-pub async fn following(
-    user_id: Uuid,
-    state: ArcState,
-    query: CollectionQuery,
-) -> Result<impl Reply, Rejection> {
+pub async fn following(user_id: Uuid, query: CollectionQuery) -> Result<impl Reply, Rejection> {
+    let state = crate::state::get();
+
     let latest_follow_activities = crate::database::follow::following(
         &state.db_pool,
         user_id,

--- a/tranquility/src/activitypub/routes/inbox.rs
+++ b/tranquility/src/activitypub/routes/inbox.rs
@@ -7,7 +7,6 @@ use {
         crypto,
         error::Error,
         map_err, match_handler,
-        state::ArcState,
     },
     core::ops::Not,
     tranquility_types::activitypub::{activity::ObjectField, Activity},
@@ -22,22 +21,18 @@ use {
 /// - Decodes the activity
 /// - Verifies the HTTP signature
 /// - Checks if the activity/object contained/referenced in the activity actually belongs to the author of the activity
-pub fn validate_request(
-    state: &ArcState,
-) -> impl Filter<Extract = (Activity,), Error = Rejection> + Clone {
-    crate::state::filter(state)
-        .and(warp::method())
+pub fn validate_request() -> impl Filter<Extract = (Activity,), Error = Rejection> + Clone {
+    warp::method()
         .and(warp::path::full())
         .and(optional_raw_query())
         .and(warp::header::headers_cloned())
         .and(ap_json())
         .and_then(verify_signature)
-        .untuple_one()
         .and_then(verify_ownership)
 }
 
 /// Checks if the activity/object contained/referenced in the activity actually belongs to the author of the activity
-async fn verify_ownership(state: ArcState, activity: Activity) -> Result<Activity, Rejection> {
+async fn verify_ownership(activity: Activity) -> Result<Activity, Rejection> {
     // It's fine if the objects or activities don't match in this case
     if activity.r#type == "Announce" || activity.r#type == "Follow" {
         return Ok(activity);
@@ -47,7 +42,7 @@ async fn verify_ownership(state: ArcState, activity: Activity) -> Result<Activit
         ObjectField::Actor(ref actor) => actor.id == activity.actor,
         ObjectField::Object(ref object) => object.attributed_to == activity.actor,
         ObjectField::Url(ref url) => {
-            let entity = fetcher::fetch_any(&state, url).await?;
+            let entity = fetcher::fetch_any(url).await?;
             entity.is_owned_by(activity.actor.as_str())
         }
     };
@@ -59,22 +54,20 @@ async fn verify_ownership(state: ArcState, activity: Activity) -> Result<Activit
 
 /// Verifies the HTTP signature with the public key of the owner of the activity
 async fn verify_signature(
-    state: ArcState,
     method: Method,
     path: FullPath,
     query: String,
     headers: HeaderMap,
     activity: Activity,
-) -> Result<(ArcState, Activity), Rejection> {
-    let (remote_actor, _remote_actor_db) =
-        map_err!(fetcher::fetch_actor(&state, &activity.actor).await)?;
+) -> Result<Activity, Rejection> {
+    let (remote_actor, _remote_actor_db) = map_err!(fetcher::fetch_actor(&activity.actor).await)?;
 
     let public_key = remote_actor.public_key.public_key_pem;
     let query = query.is_empty().not().then(|| query);
 
     crypto::request::verify(method, path, query, headers, public_key)
         .await?
-        .then(|| (state, activity))
+        .then(|| activity)
         .ok_or_else(|| Error::Unauthorized.into())
 }
 
@@ -83,11 +76,10 @@ pub async fn inbox(
     // Do we even care about the user ID?
     // Theoretically we could just use one shared inbox and get rid of the unique inboxes
     _user_id: uuid::Uuid,
-    state: ArcState,
     activity: Activity,
 ) -> Result<impl Reply, Rejection> {
     let response = match_handler! {
-        (state, activity);
+        activity;
 
         Accept,
         Announce,

--- a/tranquility/src/activitypub/routes/objects.rs
+++ b/tranquility/src/activitypub/routes/objects.rs
@@ -1,12 +1,13 @@
 use {
-    crate::{activitypub::ActivityObject, database::Object, map_err, state::ArcState},
+    crate::{activitypub::ActivityObject, database::Object, map_err},
     ormx::Table,
     tranquility_types::activitypub::IsPrivate,
     uuid::Uuid,
     warp::{http::StatusCode, reply::Response, Rejection, Reply},
 };
 
-pub async fn objects(id: Uuid, state: ArcState) -> Result<Response, Rejection> {
+pub async fn objects(id: Uuid) -> Result<Response, Rejection> {
+    let state = crate::state::get();
     let object = map_err!(Object::get(&state.db_pool, id).await)?;
     let activity_or_object: ActivityObject = map_err!(serde_json::from_value(object.data.clone()))?;
 

--- a/tranquility/src/activitypub/routes/outbox.rs
+++ b/tranquility/src/activitypub/routes/outbox.rs
@@ -2,7 +2,6 @@ use {
     super::CollectionQuery,
     crate::{
         consts::activitypub::ACTIVITIES_PER_PAGE, database::Actor as DbActor, format_uuid, map_err,
-        state::ArcState,
     },
     itertools::Itertools,
     std::ops::Not,
@@ -14,11 +13,9 @@ use {
     warp::{Rejection, Reply},
 };
 
-pub async fn outbox(
-    user_id: Uuid,
-    state: ArcState,
-    query: CollectionQuery,
-) -> Result<impl Reply, Rejection> {
+pub async fn outbox(user_id: Uuid, query: CollectionQuery) -> Result<impl Reply, Rejection> {
+    let state = crate::state::get();
+
     let latest_activities = crate::database::outbox::activities(
         &state.db_pool,
         user_id,

--- a/tranquility/src/activitypub/routes/users.rs
+++ b/tranquility/src/activitypub/routes/users.rs
@@ -1,10 +1,11 @@
 use {
-    crate::{database::Actor, map_err, state::ArcState},
+    crate::{database::Actor, map_err},
     uuid::Uuid,
     warp::{Rejection, Reply},
 };
 
-pub async fn users(uuid: Uuid, state: ArcState) -> Result<impl Reply, Rejection> {
+pub async fn users(uuid: Uuid) -> Result<impl Reply, Rejection> {
+    let state = crate::state::get();
     let actor = map_err!(Actor::get(&state.db_pool, uuid).await)?;
 
     Ok(warp::reply::json(&actor.actor))

--- a/tranquility/src/api/mastodon/apps.rs
+++ b/tranquility/src/api/mastodon/apps.rs
@@ -3,7 +3,6 @@ use {
     crate::{
         database::{InsertExt, InsertOAuthApplication},
         limit_body_size,
-        state::ArcState,
     },
     serde::Deserialize,
     uuid::Uuid,
@@ -24,10 +23,11 @@ pub struct RegisterForm {
     website: String,
 }
 
-async fn create(state: ArcState, form: RegisterForm) -> Result<impl Reply, Rejection> {
+async fn create(form: RegisterForm) -> Result<impl Reply, Rejection> {
     let client_id = Uuid::new_v4();
     let client_secret = crate::crypto::token::generate()?;
 
+    let state = crate::state::get();
     let application = InsertOAuthApplication {
         client_name: form.client_name,
         client_id,
@@ -38,17 +38,14 @@ async fn create(state: ArcState, form: RegisterForm) -> Result<impl Reply, Rejec
     }
     .insert(&state.db_pool)
     .await?;
-    let mastodon_application = application.into_mastodon(&state).await?;
+    let mastodon_application = application.into_mastodon().await?;
 
     Ok(warp::reply::json(&mastodon_application))
 }
 
-pub fn routes(state: &ArcState) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
-    let state = crate::state::filter(state);
-
+pub fn routes() -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     let routes = warp::path!("apps")
         .and(warp::post())
-        .and(state)
         .and(urlencoded_or_json())
         .and_then(create);
     // Restrict the body size

--- a/tranquility/src/api/mastodon/instance.rs
+++ b/tranquility/src/api/mastodon/instance.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{consts::VERSION, state::ArcState},
+    crate::consts::VERSION,
     tranquility_types::mastodon::{
         instance::{Stats, Urls},
         Instance,
@@ -7,7 +7,8 @@ use {
     warp::{Filter, Rejection, Reply},
 };
 
-async fn instance(state: ArcState) -> Result<impl Reply, Rejection> {
+async fn instance() -> Result<impl Reply, Rejection> {
+    let state = crate::state::get();
     let streaming_api = format!("wss://{}", state.config.instance.domain);
 
     let instance = Instance {
@@ -33,8 +34,6 @@ async fn instance(state: ArcState) -> Result<impl Reply, Rejection> {
     Ok(warp::reply::json(&instance))
 }
 
-pub fn routes(state: &ArcState) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
-    let state = crate::state::filter(state);
-
-    warp::path!("instance").and(state).and_then(instance)
+pub fn routes() -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+    warp::path!("instance").and_then(instance)
 }

--- a/tranquility/src/api/mastodon/mod.rs
+++ b/tranquility/src/api/mastodon/mod.rs
@@ -4,7 +4,6 @@ use {
         database::{Actor, OAuthToken},
         error::Error,
         map_err,
-        state::ArcState,
         util::construct_cors,
     },
     headers::authorization::{Bearer, Credentials},
@@ -24,8 +23,10 @@ static DEFAULT_APPLICATION: Lazy<App> = Lazy::new(|| App {
 });
 
 /// Filter that can decode the body as an URL-encoded or an JSON-encoded form
-pub fn urlencoded_or_json<T: DeserializeOwned + Send>(
-) -> impl Filter<Extract = (T,), Error = Rejection> + Copy {
+pub fn urlencoded_or_json<T>() -> impl Filter<Extract = (T,), Error = Rejection> + Copy
+where
+    T: DeserializeOwned + Send,
+{
     let urlencoded_filter = warp::body::form();
     let json_filter = warp::body::json();
 
@@ -33,9 +34,8 @@ pub fn urlencoded_or_json<T: DeserializeOwned + Send>(
 }
 
 /// Same as [`authorise_user`] but makes the bearer token optional
-pub fn authorisation_optional(
-    state: &ArcState,
-) -> impl Filter<Extract = (Option<Actor>,), Error = Rejection> + Clone {
+pub fn authorisation_optional() -> impl Filter<Extract = (Option<Actor>,), Error = Rejection> + Clone
+{
     let or_none_fn = |error: Rejection| async move {
         if error.find::<MissingHeader>().is_some() {
             Ok((None,))
@@ -44,18 +44,16 @@ pub fn authorisation_optional(
         }
     };
 
-    authorisation_required(state).map(Some).or_else(or_none_fn)
+    authorisation_required().map(Some).or_else(or_none_fn)
 }
 
 /// Parses a `HeaderValue` as the contents of an authorization header with bearer token contents
 /// and attempts to fetch the user from the database
-async fn authorise_user(
-    state: ArcState,
-    authorization_header: HeaderValue,
-) -> Result<Actor, Rejection> {
+async fn authorise_user(authorization_header: HeaderValue) -> Result<Actor, Rejection> {
     let credentials = Bearer::decode(&authorization_header).ok_or(Error::Unauthorized)?;
     let token = credentials.token();
 
+    let state = crate::state::get();
     let access_token = map_err!(OAuthToken::by_access_token(&state.db_pool, token).await)?;
     let actor = map_err!(Actor::get(&state.db_pool, access_token.actor_id).await)?;
 
@@ -65,25 +63,21 @@ async fn authorise_user(
 /// Filter that gets the user associated with the bearer token from the database
 ///
 /// Rejects if the user cannot be found
-pub fn authorisation_required(
-    state: &ArcState,
-) -> impl Filter<Extract = (Actor,), Error = Rejection> + Clone {
-    crate::state::filter(state)
-        .and(warp::header::value(AUTHORIZATION.as_ref()))
-        .and_then(authorise_user)
+pub fn authorisation_required() -> impl Filter<Extract = (Actor,), Error = Rejection> + Clone {
+    warp::header::value(AUTHORIZATION.as_ref()).and_then(authorise_user)
 }
 
-pub fn routes(state: &ArcState) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+pub fn routes() -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     // Enable CORS for all API endpoints
     // See: https://github.com/tootsuite/mastodon/blob/85324837ea1089c00fb4aefc31a7242847593b52/config/initializers/cors.rb
     let cors = construct_cors(API_ALLOWED_METHODS);
 
     let v1_prefix = warp::path!("api" / "v1" / ..);
 
-    let accounts = accounts::routes(state);
-    let apps = apps::routes(state);
-    let statuses = statuses::routes(state);
-    let instance = instance::routes(state);
+    let accounts = accounts::routes();
+    let apps = apps::routes();
+    let statuses = statuses::routes();
+    let instance = instance::routes();
 
     let v1_routes = accounts.or(apps).or(statuses).or(instance);
 

--- a/tranquility/src/api/mod.rs
+++ b/tranquility/src/api/mod.rs
@@ -1,18 +1,17 @@
 use {
-    crate::state::ArcState,
     cfg_if::cfg_if,
     warp::{Filter, Rejection, Reply},
 };
 
-pub fn routes(state: &ArcState) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
-    let oauth = oauth::routes(state);
-    let register = register::routes(state);
+pub fn routes() -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+    let oauth = oauth::routes();
+    let register = register::routes();
 
     let auth_api = oauth.or(register);
 
     cfg_if! {
         if #[cfg(feature = "mastodon-api")] {
-            mastodon::routes(state).or(auth_api)
+            mastodon::routes().or(auth_api)
         } else {
             auth_api
         }

--- a/tranquility/src/api/oauth/authorize.rs
+++ b/tranquility/src/api/oauth/authorize.rs
@@ -5,7 +5,6 @@ use {
         database::{Actor, InsertExt, InsertOAuthAuthorization, OAuthApplication},
         error::Error,
         map_err,
-        state::ArcState,
     },
     askama::Template,
     chrono::Duration,
@@ -38,7 +37,8 @@ pub async fn get() -> Result<impl Reply, Rejection> {
     Ok(warp::reply::html(AUTHORIZE_FORM.as_str()))
 }
 
-pub async fn post(state: ArcState, form: Form, query: Query) -> Result<Response, Rejection> {
+pub async fn post(form: Form, query: Query) -> Result<Response, Rejection> {
+    let state = crate::state::get();
     let actor = Actor::by_username_local(&state.db_pool, &form.username).await?;
     if !password::verify(form.password, actor.password_hash.unwrap()).await {
         return Err(Error::Unauthorized.into());

--- a/tranquility/src/api/oauth/mod.rs
+++ b/tranquility/src/api/oauth/mod.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        consts::cors::OAUTH_TOKEN_ALLOWED_METHODS, limit_body_size, state::ArcState,
-        util::construct_cors,
-    },
+    crate::{consts::cors::OAUTH_TOKEN_ALLOWED_METHODS, limit_body_size, util::construct_cors},
     askama::Template,
     once_cell::sync::Lazy,
     tranquility_ratelimit::{ratelimit, Configuration as RatelimitConfig},
@@ -23,19 +20,15 @@ struct TokenTemplate {
 }
 
 fn authorize_route<F>(
-    state: &ArcState,
     ratelimit_filter: F,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone
 where
     F: Filter<Extract = (), Error = Rejection> + Clone + Send + Sync + 'static,
 {
-    let state = crate::state::filter(state);
-
     let get = warp::get().and_then(authorize::get);
 
     // Ratelimit only the logic
     let post = warp::post()
-        .and(state)
         .and(warp::body::form())
         .and(warp::query())
         .and_then(authorize::post)
@@ -47,14 +40,11 @@ where
 }
 
 fn token_route<F>(
-    state: &ArcState,
     ratelimit_filter: F,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone
 where
     F: Filter<Extract = (), Error = Rejection> + Clone + Send + Sync + 'static,
 {
-    let state = crate::state::filter(state);
-
     // Enable CORS for the token endpoint
     // See: https://github.com/tootsuite/mastodon/blob/85324837ea1089c00fb4aefc31a7242847593b52/config/initializers/cors.rb
     let cors = construct_cors(OAUTH_TOKEN_ALLOWED_METHODS);
@@ -62,25 +52,26 @@ where
 
     // Ratelimit only the logic
     let token_logic = warp::post()
-        .and(state)
         .and(warp::body::form())
         .and_then(token::token)
         .with(ratelimit!(from_filter: ratelimit_filter));
+
     // Restrict the body size
     let token_logic = limit_body_size!(token_logic);
 
     token_path.and(token_logic).with(cors)
 }
 
-pub fn routes(state: &ArcState) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+pub fn routes() -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+    let state = crate::state::get();
     let ratelimit_config = RatelimitConfig::new()
         .active(state.config.ratelimit.active)
         .burst_quota(state.config.ratelimit.authentication_quota);
     let ratelimit_filter =
         ratelimit(ratelimit_config).expect("Couldn't construct a ratelimit filter");
 
-    let authorize = authorize_route(state, ratelimit_filter.clone());
-    let token = token_route(state, ratelimit_filter);
+    let authorize = authorize_route(ratelimit_filter.clone());
+    let token = token_route(ratelimit_filter);
 
     authorize.or(token)
 }

--- a/tranquility/src/macros.rs
+++ b/tranquility/src/macros.rs
@@ -3,9 +3,9 @@
 /// If it doesn't, the error gets logged and the function continues  
 #[macro_export]
 macro_rules! attempt_fetch {
-    ($state:ident, $url:ident, [$($func:ident),+]) => {{
+    ($url:ident, [$($func:ident),+]) => {{
         $(
-            match $func($state, $url).await {
+            match $func($url).await {
                 Ok(val) => return Ok(val.into()),
                 Err(err) => tracing::debug!(error = ?err, "Couldn't fetch entity"),
             }
@@ -183,7 +183,7 @@ macro_rules! map_err {
 #[macro_export]
 macro_rules! match_handler {
     {
-        ($state:ident, $activity:ident);
+        $activity:ident;
 
         $($type:ident),+
     } => {
@@ -191,7 +191,7 @@ macro_rules! match_handler {
             match $activity.r#type.as_str() {
                 $(
                     stringify!($type) =>
-                        crate::activitypub::handler::[<$type:lower>]::handle(&$state, $activity).await,
+                        crate::activitypub::handler::[<$type:lower>]::handle($activity).await,
                 )+
                 _ => Err(crate::error::Error::UnknownActivity),
             }

--- a/tranquility/src/main.rs
+++ b/tranquility/src/main.rs
@@ -20,14 +20,10 @@ cfg_if::cfg_if! {
 
 #[tokio::main]
 async fn main() {
-    let state = cli::run().await;
+    cli::run().await;
+    daemon::start();
 
-    database::migrate(&state.db_pool)
-        .await
-        .expect("Database migration failed");
-    daemon::start(&state);
-
-    server::run(state).await;
+    server::run().await;
 }
 
 mod activitypub;

--- a/tranquility/src/server.rs
+++ b/tranquility/src/server.rs
@@ -1,18 +1,18 @@
-use {crate::state::ArcState, std::net::IpAddr, warp::Filter};
+use {std::net::IpAddr, warp::Filter};
 
 /// Combine all route filters and start a warp server
-pub async fn run(state: ArcState) {
+pub async fn run() {
     let logging = warp::trace::request();
 
-    let activitypub = crate::activitypub::routes::routes(&state);
-    let api = crate::api::routes(&state);
-    let well_known = crate::well_known::routes(&state);
+    let activitypub = crate::activitypub::routes::routes();
+    let api = crate::api::routes();
+    let well_known = crate::well_known::routes();
 
     let routes = activitypub.or(api).or(well_known);
 
     #[cfg(feature = "email")]
     let routes = {
-        let email = crate::email::routes(&state);
+        let email = crate::email::routes();
         routes.or(email)
     };
 
@@ -20,6 +20,7 @@ pub async fn run(state: ArcState) {
 
     let server = warp::serve(routes);
 
+    let state = crate::state::get();
     let config = &state.config;
 
     let interface = config.server.interface.parse::<IpAddr>().unwrap();

--- a/tranquility/src/state.rs
+++ b/tranquility/src/state.rs
@@ -1,13 +1,16 @@
+use notify::RecursiveMode;
+
 use {
     crate::config::Configuration,
+    arc_swap::{ArcSwap, Guard},
+    notify::{Event, EventKind, Watcher},
+    once_cell::sync::OnceCell,
     sqlx::PgPool,
-    std::{convert::Infallible, sync::Arc},
-    warp::Filter,
+    std::{path::Path, sync::Arc},
+    tokio::runtime::Handle,
 };
 
-#[allow(clippy::module_name_repetitions)]
-/// State wrapped into an arc
-pub type ArcState = Arc<State>;
+static STATE: OnceCell<ArcSwap<State>> = OnceCell::new();
 
 /// Application-wide state
 pub struct State {
@@ -16,20 +19,98 @@ pub struct State {
 }
 
 impl State {
-    /// Create a new state instance wrapped into an Arc
-    pub fn new(config: Configuration, db_pool: PgPool) -> ArcState {
+    /// Create a new state instance
+    pub fn new(config: Configuration, db_pool: PgPool) -> Arc<Self> {
         Arc::new(Self::new_arcless(config, db_pool))
     }
 
-    /// Create a new state instance
+    /// Create a new state instance without an arc
     pub fn new_arcless(config: Configuration, db_pool: PgPool) -> Self {
         Self { config, db_pool }
     }
 }
 
-/// Create a filter that returns an arc-ed instance of the contained state
-pub fn filter(state: &ArcState) -> impl Filter<Extract = (ArcState,), Error = Infallible> + Clone {
-    let state = Arc::clone(state);
+/// Load the configuration and connect to the database
+#[inline]
+async fn prepare_state<P>(path: P) -> Arc<State>
+where
+    P: AsRef<Path>,
+{
+    let config = crate::config::load(path).await;
+    let db_pool = crate::database::connection::init_pool(&config.server.database_url)
+        .await
+        .expect("Couldn't connect to database");
 
-    warp::any().map(move || Arc::clone(&state))
+    // It's maybe a bit excessive the migrate the database everytime the configuration file is changed
+    // But the database URL might change, so..
+    crate::database::migrate(&db_pool)
+        .await
+        .expect("Failed to migrate the database");
+
+    State::new(config, db_pool)
+}
+
+/// Initialise the configuration OnceCell
+pub async fn init<P>(path: P)
+where
+    P: AsRef<Path>,
+{
+    let path = path.as_ref().to_path_buf();
+
+    let state = prepare_state(&path).await;
+    init_raw(state);
+
+    // Obtain a handle to the current runtime for use inside the event function
+    let handle = Handle::current();
+
+    let mut watcher = {
+        let path = path.clone();
+
+        notify::recommended_watcher(move |event| {
+            // Other events don't really make sense
+            match event {
+                Ok(Event {
+                    kind: EventKind::Modify(..),
+                    ..
+                }) => {
+                    let state = handle.block_on(prepare_state(&path));
+                    STATE.get().unwrap().swap(state);
+
+                    #[cfg(feature = "email")]
+                    crate::email::update_transport();
+                }
+                Err(err) => warn!(error = ?err, "File watching failed"),
+                _ => (),
+            }
+        })
+        .expect("Failed to initialise file watcher")
+    };
+
+    watcher
+        .watch(&path, RecursiveMode::NonRecursive)
+        .expect("Failed to watch configuration file");
+}
+
+/// Initialise the state from a raw struct
+pub fn init_raw(state: Arc<State>) {
+    let state = ArcSwap::new(state);
+
+    STATE
+        .set(state)
+        .map_err(|_| ())
+        .expect("State OnceCell already initialised");
+}
+
+/// Get a reference to the global configuration
+#[inline]
+pub fn get() -> Guard<Arc<State>> {
+    STATE.get().expect("State uninitialised").load()
+}
+
+/// Get a clone of the inner arc
+///
+/// Doesn't take up a cheap proxy. Useful for long running tasks
+#[inline]
+pub fn get_full() -> Arc<State> {
+    STATE.get().expect("State uninitialised").load_full()
 }

--- a/tranquility/src/tests/follow_activity.rs
+++ b/tranquility/src/tests/follow_activity.rs
@@ -1,0 +1,24 @@
+use crate::activitypub::FollowActivity;
+
+const FOLLOW_ACTIVITY: &str = r#"
+{
+    "cc": ["https://www.w3.org/ns/activitystreams#Public"],
+    "id": "https://a.example.com/activities/8dcc256a-8c3f-49ee-ab22-bb51c9082260",
+    "to": ["https://b.example.com/users/test"],
+    "type": "Follow",
+    "actor": "https://a.example.com/users/test",
+    "state": "pending",
+    "object": "https://b.example.com/users/test",
+    "context": "https://a.example.com/contexts/9c3b4420-dd74-454b-8124-c4759b849f3a",
+    "published": "2019-08-20T14:02:09.995388Z",
+    "context_id": 8
+}
+"#;
+
+#[test]
+pub fn decode_follow_activity() {
+    let follow_activity: FollowActivity = serde_json::from_str(FOLLOW_ACTIVITY).unwrap();
+
+    assert_eq!(follow_activity.activity.r#type, "Follow");
+    assert!(!follow_activity.approved);
+}

--- a/tranquility/src/tests/mod.rs
+++ b/tranquility/src/tests/mod.rs
@@ -1,6 +1,5 @@
 use {
     crate::{
-        activitypub::FollowActivity,
         config::{
             Configuration, ConfigurationEmail, ConfigurationInstance, ConfigurationJaeger,
             ConfigurationRatelimit, ConfigurationServer, ConfigurationTls,
@@ -10,21 +9,6 @@ use {
     sqlx::PgPool,
     std::env,
 };
-
-const FOLLOW_ACTIVITY: &str = r#"
-{
-    "cc": ["https://www.w3.org/ns/activitystreams#Public"],
-    "id": "https://a.example.com/activities/8dcc256a-8c3f-49ee-ab22-bb51c9082260",
-    "to": ["https://b.example.com/users/test"],
-    "type": "Follow",
-    "actor": "https://a.example.com/users/test",
-    "state": "pending",
-    "object": "https://b.example.com/users/test",
-    "context": "https://a.example.com/contexts/9c3b4420-dd74-454b-8124-c4759b849f3a",
-    "published": "2019-08-20T14:02:09.995388Z",
-    "context_id": 8
-}
-"#;
 
 fn test_config() -> Configuration {
     Configuration {
@@ -82,14 +66,6 @@ async fn init_state() {
 
     let state = State::new(config, db_pool);
     crate::state::init_raw(state);
-}
-
-#[test]
-fn decode_follow_activity() {
-    let follow_activity: FollowActivity = serde_json::from_str(FOLLOW_ACTIVITY).unwrap();
-
-    assert_eq!(follow_activity.activity.r#type, "Follow");
-    assert!(!follow_activity.approved);
 }
 
 mod nodeinfo;

--- a/tranquility/src/tests/mod.rs
+++ b/tranquility/src/tests/mod.rs
@@ -76,11 +76,12 @@ async fn init_db() -> PgPool {
     conn_pool
 }
 
-async fn test_state() -> State {
+async fn init_state() {
     let config = test_config();
     let db_pool = init_db().await;
 
-    State::new_arcless(config, db_pool)
+    let state = State::new(config, db_pool);
+    crate::state::init_raw(state);
 }
 
 #[test]

--- a/tranquility/src/tests/nodeinfo.rs
+++ b/tranquility/src/tests/nodeinfo.rs
@@ -1,4 +1,4 @@
-use {super::test_state, std::sync::Arc};
+use super::init_state;
 
 const NODEINFO_21_SCHEMA: &str = r#"
 {
@@ -192,9 +192,9 @@ const NODEINFO_21_SCHEMA: &str = r#"
 
 #[tokio::test]
 async fn nodeinfo() {
-    let state = Arc::new(test_state().await);
+    init_state().await;
 
-    let well_known = crate::well_known::routes(&state);
+    let well_known = crate::well_known::routes();
 
     let response = warp::test::request()
         .path("/.well-known/nodeinfo/2.1")

--- a/tranquility/src/util/mention.rs
+++ b/tranquility/src/util/mention.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        consts::regex::MENTION, database::Actor as DbActor, error::Error, regex, state::ArcState,
+        consts::regex::MENTION, database::Actor as DbActor, error::Error, regex,
         well_known::webfinger,
     },
     async_trait::async_trait,
@@ -54,13 +54,13 @@ where
 
 pub trait FormatMention {
     /// Format the mentions to links
-    async fn format_mentions(&mut self, state: ArcState) -> Vec<Tag>;
+    async fn format_mentions(&mut self) -> Vec<Tag>;
 }
 
 #[async_trait]
 impl FormatMention for Object {
-    async fn format_mentions(&mut self, state: ArcState) -> Vec<Tag> {
-        let tags = self.content.format_mentions(state).await;
+    async fn format_mentions(&mut self) -> Vec<Tag> {
+        let tags = self.content.format_mentions().await;
         self.tag = tags.clone();
 
         tags
@@ -69,7 +69,7 @@ impl FormatMention for Object {
 
 #[async_trait]
 impl FormatMention for String {
-    async fn format_mentions(&mut self, state: ArcState) -> Vec<Tag> {
+    async fn format_mentions(&mut self) -> Vec<Tag> {
         let handle = Handle::current();
         let text = self.clone();
 
@@ -91,11 +91,11 @@ impl FormatMention for String {
                     // If a domain is present, use webfinger
                     // Otherwise query the local accounts
                     let actor = if let Some(domain) = domain {
-                        let (actor, _db_actor) =
-                            webfinger::fetch_actor(&state, username, domain).await?;
+                        let (actor, _db_actor) = webfinger::fetch_actor(username, domain).await?;
 
                         actor
                     } else {
+                        let state = crate::state::get();
                         let db_actor = DbActor::by_username_local(&state.db_pool, username).await?;
                         let actor: Actor = serde_json::from_value(db_actor.actor)?;
 

--- a/tranquility/src/well_known/mod.rs
+++ b/tranquility/src/well_known/mod.rs
@@ -1,10 +1,7 @@
-use {
-    crate::state::ArcState,
-    warp::{Filter, Rejection, Reply},
-};
+use warp::{Filter, Rejection, Reply};
 
-pub fn routes(state: &ArcState) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
-    let routes = nodeinfo::routes(state).or(webfinger::routes(state));
+pub fn routes() -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+    let routes = nodeinfo::routes().or(webfinger::routes());
 
     warp::path!(".well-known" / ..).and(routes)
 }


### PR DESCRIPTION
Add automatic configuration refresh

When the configuration file gets changed, the server reloads the configuration, reconnects to the database pool and executes the migrations again

If the email feature is activated, it also replaces the SMTP transport

 - [x] Implement
 - [ ] Feature gate
 - [ ] Clean up