### PR TITLE
fix: Fix clippy lints

### DIFF
--- a/tranquility-ratelimit/src/lib.rs
+++ b/tranquility-ratelimit/src/lib.rs
@@ -111,8 +111,8 @@ impl TryInto<Quota> for Configuration {
 }
 
 /// Check if the IP is ratelimited. If it is, reject the request
-async fn check_ratelimit(
-    rate_limiter: ArcRatelimiter,
+fn check_ratelimit(
+    rate_limiter: &ArcRatelimiter,
     ip_address: Option<SocketAddr>,
 ) -> Result<(), Rejection> {
     let ip_address = ip_address.unwrap();
@@ -132,6 +132,8 @@ async fn check_ratelimit(
 /// (I currently don't know any other way to achieve this with warp)
 ///
 #[doc(hidden)]
+// this function needs to return a `TryFuture`
+#[allow(clippy::unused_async)]
 pub async fn __recover_fn(rejection: Rejection) -> Result<impl Reply, Rejection> {
     if let Some(wait_until) = rejection.find::<WaitUntil>() {
         let wait_until = wait_until.0;
@@ -163,7 +165,7 @@ pub fn ratelimit(
 
             async move {
                 if active {
-                    check_ratelimit(rate_limiter, ip_address).await
+                    check_ratelimit(&rate_limiter, ip_address)
                 } else {
                     Ok(())
                 }

--- a/tranquility/src/activitypub/deliverer.rs
+++ b/tranquility/src/activitypub/deliverer.rs
@@ -184,7 +184,7 @@ pub async fn deliver(activity: Activity, state: ArcState) -> Result<(), Error> {
                     warn!(
                         "Delivery request wasn't successful\nStatus code: {}\nServer response: {}",
                         response_status, response_body,
-                    )
+                    );
                 }
                 Err(err) => warn!("Delivery request failed: {}", err),
             }

--- a/tranquility/src/activitypub/handler/announce.rs
+++ b/tranquility/src/activitypub/handler/announce.rs
@@ -14,9 +14,9 @@ pub async fn handle(state: &ArcState, activity: Activity) -> Result<StatusCode, 
     let object_url = activity.object.as_url().ok_or(Error::UnknownActivity)?;
 
     // Fetch the object (just in case)
-    fetcher::fetch_object(&state, &object_url).await?;
+    fetcher::fetch_object(state, object_url).await?;
     // Fetch the actor (just in case)
-    fetcher::fetch_actor(&state, &activity.actor).await?;
+    fetcher::fetch_actor(state, &activity.actor).await?;
 
     let actor = Actor::by_url(&state.db_pool, &activity.actor).await?;
     let activity_value = serde_json::to_value(&activity)?;

--- a/tranquility/src/activitypub/handler/like.rs
+++ b/tranquility/src/activitypub/handler/like.rs
@@ -14,9 +14,9 @@ pub async fn handle(state: &ArcState, activity: Activity) -> Result<StatusCode, 
     let object_url = activity.object.as_url().ok_or(Error::UnknownActivity)?;
 
     // Fetch the object (just in case)
-    fetcher::fetch_object(&state, &object_url).await?;
+    fetcher::fetch_object(state, object_url).await?;
     // Fetch the actor (just in case)
-    fetcher::fetch_actor(&state, &activity.actor).await?;
+    fetcher::fetch_actor(state, &activity.actor).await?;
     let actor = Actor::by_url(&state.db_pool, &activity.actor).await?;
 
     let activity_value = serde_json::to_value(&activity)?;

--- a/tranquility/src/api/mastodon/apps.rs
+++ b/tranquility/src/api/mastodon/apps.rs
@@ -26,7 +26,7 @@ pub struct RegisterForm {
 
 async fn create(state: ArcState, form: RegisterForm) -> Result<impl Reply, Rejection> {
     let client_id = Uuid::new_v4();
-    let client_secret = crate::crypto::token::generate()?;
+    let client_secret = crate::crypto::token::generate();
 
     let application = InsertOAuthApplication {
         client_name: form.client_name,

--- a/tranquility/src/api/mastodon/instance.rs
+++ b/tranquility/src/api/mastodon/instance.rs
@@ -7,6 +7,7 @@ use {
     warp::{Filter, Rejection, Reply},
 };
 
+#[allow(clippy::unused_async)]
 async fn instance(state: ArcState) -> Result<impl Reply, Rejection> {
     let streaming_api = format!("wss://{}", state.config.instance.domain);
 

--- a/tranquility/src/api/oauth/authorize.rs
+++ b/tranquility/src/api/oauth/authorize.rs
@@ -34,6 +34,7 @@ pub struct Query {
     state: String,
 }
 
+#[allow(clippy::unused_async)]
 pub async fn get() -> Result<impl Reply, Rejection> {
     Ok(warp::reply::html(AUTHORIZE_FORM.as_str()))
 }
@@ -58,7 +59,7 @@ pub async fn post(state: ArcState, form: Form, query: Query) -> Result<Response,
         return Err(Error::InvalidRequest.into());
     }
 
-    let authorization_code = crate::crypto::token::generate()?;
+    let authorization_code = crate::crypto::token::generate();
 
     let validity_duration = *AUTHORIZATION_CODE_VALIDITY;
     let valid_until = chrono::Utc::now() + validity_duration;

--- a/tranquility/src/api/oauth/token.rs
+++ b/tranquility/src/api/oauth/token.rs
@@ -109,7 +109,7 @@ async fn code_grant(
     let valid_until = *ACCESS_TOKEN_VALID_DURATION;
     let valid_until = chrono::Utc::now() + valid_until;
 
-    let access_token = crate::crypto::token::generate()?;
+    let access_token = crate::crypto::token::generate();
 
     let access_token = InsertOAuthToken {
         application_id: Some(client.id),
@@ -154,7 +154,7 @@ async fn password_grant(
     let valid_until = *ACCESS_TOKEN_VALID_DURATION;
     let valid_until = chrono::Utc::now() + valid_until;
 
-    let access_token = crate::crypto::token::generate()?;
+    let access_token = crate::crypto::token::generate();
 
     let access_token = InsertOAuthToken {
         application_id: None,

--- a/tranquility/src/crypto.rs
+++ b/tranquility/src/crypto.rs
@@ -5,6 +5,7 @@ use rand::{
 };
 
 /// Generate a type that supports being generated via `rand::Rng::gen()` using `OsRng`
+#[inline]
 pub fn gen_secure_rand<T>() -> T
 where
     Standard: Distribution<T>,
@@ -82,14 +83,14 @@ pub mod rsa {
 }
 
 pub mod token {
-    use crate::{consts::crypto::TOKEN_LENGTH, error::Error};
+    use crate::consts::crypto::TOKEN_LENGTH;
 
     /// Generate a cryptographically random token (length defined in the `consts` file)
-    pub fn generate() -> Result<String, Error> {
+    pub fn generate() -> String {
         // Two characters are needed to encode one byte as hex
         let token = crate::crypto::gen_secure_rand::<[u8; TOKEN_LENGTH / 2]>();
 
-        Ok(hex::encode(token))
+        hex::encode(token)
     }
 }
 

--- a/tranquility/src/error.rs
+++ b/tranquility/src/error.rs
@@ -79,6 +79,7 @@ pub enum Error {
 impl Reject for Error {}
 
 /// Recover function for recovering from some of the errors with a custom error status
+#[allow(clippy::unused_async)]
 pub async fn recover(rejection: Rejection) -> Result<Response, Rejection> {
     if let Some(error) = rejection.find::<Error>() {
         let error_text = error.to_string();

--- a/tranquility/src/main.rs
+++ b/tranquility/src/main.rs
@@ -1,6 +1,6 @@
 #![forbid(unsafe_code)]
-#![warn(clippy::all, clippy::pedantic)]
 #![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::doc_markdown, clippy::module_name_repetitions)]
 // Needed because of conditional compilation
 #![allow(clippy::used_underscore_binding)]
@@ -18,6 +18,8 @@ cfg_if::cfg_if! {
     }
 }
 
+// allow because of tokio macro
+#[allow(clippy::semicolon_if_nothing_returned)]
 #[tokio::main]
 async fn main() {
     let state = cli::run().await;

--- a/tranquility/src/server.rs
+++ b/tranquility/src/server.rs
@@ -31,8 +31,8 @@ pub async fn run(state: ArcState) {
             .cert_path(&config.tls.certificate)
             .key_path(&config.tls.secret_key)
             .run(addr)
-            .await
+            .await;
     } else {
-        server.run(addr).await
+        server.run(addr).await;
     }
 }

--- a/tranquility/src/tests/mod.rs
+++ b/tranquility/src/tests/mod.rs
@@ -1,3 +1,6 @@
+// i'll allow this lint module-wide because expanded tokio macros
+#![allow(clippy::semicolon_if_nothing_returned)]
+
 use {
     crate::{
         activitypub::FollowActivity,

--- a/tranquility/src/tests/nodeinfo.rs
+++ b/tranquility/src/tests/nodeinfo.rs
@@ -208,5 +208,5 @@ async fn nodeinfo() {
 
     let schema = serde_json::from_str(NODEINFO_21_SCHEMA).expect("Couldn't parse nodeinfo schema");
 
-    assert!(jsonschema::is_valid(&schema, &response_body))
+    assert!(jsonschema::is_valid(&schema, &response_body));
 }

--- a/tranquility/src/util/mention.rs
+++ b/tranquility/src/util/mention.rs
@@ -149,7 +149,7 @@ mod test {
     fn local_mention() {
         let mentions = LOCAL_MENTION.mentions();
 
-        assert_eq!(mentions, [Mention::new("alice", None)])
+        assert_eq!(mentions, [Mention::new("alice", None)]);
     }
 
     #[test]
@@ -164,13 +164,13 @@ mod test {
                 Mention::new("carol", Some("the.third.example.com")),
                 Mention::new("dave", Some("fourth.example.com")),
             ]
-        )
+        );
     }
 
     #[test]
     fn remote_mention() {
         let mentions = REMOTE_MENTION.mentions();
 
-        assert_eq!(mentions, [Mention::new("bob", Some("example.com"))])
+        assert_eq!(mentions, [Mention::new("bob", Some("example.com"))]);
     }
 }

--- a/tranquility/src/well_known/nodeinfo.rs
+++ b/tranquility/src/well_known/nodeinfo.rs
@@ -7,6 +7,7 @@ use {
     warp::{Filter, Rejection, Reply},
 };
 
+#[allow(clippy::unused_async)]
 async fn nodeinfo(state: ArcState) -> Result<impl Reply, Rejection> {
     let info = Nodeinfo {
         protocols: vec!["activitypub".into()],
@@ -27,6 +28,7 @@ async fn nodeinfo(state: ArcState) -> Result<impl Reply, Rejection> {
     Ok(warp::reply::json(&info))
 }
 
+#[allow(clippy::unused_async)]
 async fn nodeinfo_links(state: ArcState) -> Result<impl Reply, Rejection> {
     let entity_link = format!(
         "https://{}/.well-known/nodeinfo/2.1",


### PR DESCRIPTION
Rust 1.54 introduced new clippy lints. This fixes the warnings associated with them